### PR TITLE
Keep the original iterable tuple if the data class is defined by a ty…

### DIFF
--- a/src/yasoo/deserialization.py
+++ b/src/yasoo/deserialization.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from enum import Enum
 from importlib import import_module

--- a/src/yasoo/deserialization.py
+++ b/src/yasoo/deserialization.py
@@ -88,11 +88,13 @@ class Deserializer:
     ):
         if is_obj_supported_primitive(data):
             return data
+        real_type = None
         if isinstance(data, list):
             if obj_type is not None:
-                _, generic_args = normalize_type(obj_type)
+                real_type, generic_args = normalize_type(obj_type)
                 obj_type = generic_args[0] if generic_args else None
-            return [self._deserialize(d, obj_type, type_key, globals) for d in data]
+            type_to_instantiate = real_type if real_type and not inspect.isabstract(real_type) else list
+            return type_to_instantiate(self._deserialize(d, obj_type, type_key, globals) for d in data)
 
         obj_type = self._get_object_type(obj_type, data, type_key, globals)
         if type_key in data:

--- a/tests/test_dataclass_deserialization.py
+++ b/tests/test_dataclass_deserialization.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Tuple
 from unittest import TestCase
 
 from yasoo import deserialize
@@ -125,6 +125,23 @@ if DATACLASSES_EXIST:
             self.assertEqual(1, len(b.foo))
             self.assertIsInstance(b.foo[0], Foo)
             self.assertEqual(b.foo[0].a, 5)
+
+        def test_dataclass_deserialization_with_generic_tuple_type_hint(self):
+            @dataclass
+            class Foo:
+                a: Any
+
+            @dataclass
+            class Bar:
+                foo: Tuple[Foo]
+
+            b = deserialize({'foo': [{'a': 5}]}, Bar, globals=locals())
+            self.assertIsInstance(b, Bar)
+            self.assertIsInstance(b.foo, tuple)
+            self.assertEqual(1, len(b.foo))
+            self.assertIsInstance(b.foo[0], Foo)
+            self.assertEqual(b.foo[0].a, 5)
+
 
         def test_dataclass_deserialization_with_generic_dict_type_hint(self):
             @dataclass


### PR DESCRIPTION
…pe that it's origin is not abstract such as Set, Tuple, OrderedDict etc. Abstract origins such as Sequence and Iterable will still be deserialized as lists if the preserve flag is not given.